### PR TITLE
WaitForToplogyChange() caused race condition in tests

### DIFF
--- a/Rachis.Tests/RaftTestsBase.cs
+++ b/Rachis.Tests/RaftTestsBase.cs
@@ -71,7 +71,11 @@ namespace Rachis.Tests
 		protected ManualResetEventSlim WaitForToplogyChange(RaftEngine node)
 		{
 			var mre = new ManualResetEventSlim();
-			node.TopologyChanged += state => mre.Set();
+			node.TopologyChanged += state =>
+			{
+				if (node.CurrentTopology.HasVoters)
+					mre.Set();
+			};
 			return mre;
 		}
 

--- a/Rachis.Tests/TopologyChangesTests.cs
+++ b/Rachis.Tests/TopologyChangesTests.cs
@@ -208,18 +208,24 @@ namespace Rachis.Tests
 		[InlineData(2)]
 		[InlineData(3)]
 		[InlineData(4)]
+		[InlineData(7)]
 		public void Node_added_to_cluster_should_update_peers_list(int nodeCount)
 		{
+			WriteLine("--> Started test");
 			var leader = CreateNetworkAndGetLeader(nodeCount);
+			WriteLine("--> Selected leader, creating additional node");
 			using (var additionalNode = NewNodeFor(leader))
 			{
 				var clusterChanged = WaitForToplogyChangeOnCluster();
 				var newNodeAdded = WaitForToplogyChange(additionalNode);
 
+				WriteLine("Adding the additional node (name = {0}) to cluster", additionalNode.Name);
 				leader.AddToClusterAsync(new NodeConnectionInfo { Name = additionalNode.Name }).Wait();
 
 				clusterChanged.Wait();
 				newNodeAdded.Wait();
+
+				WriteLine("--> Cluster finished changing, new node added.");
 
 				var raftNodes = Nodes.ToList();
 				foreach (var node in raftNodes)

--- a/Rachis/Behaviors/AbstractRaftStateBehavior.cs
+++ b/Rachis/Behaviors/AbstractRaftStateBehavior.cs
@@ -34,6 +34,7 @@ namespace Rachis.Behaviors
 			    {
 				    Requested = new Topology(msg.ClusterTopologyId)
 			    };
+
 			    Engine.StartTopologyChange(tcc);
 				Engine.CommitTopologyChange(tcc);
 			    return true;

--- a/Rachis/RaftEngine.cs
+++ b/Rachis/RaftEngine.cs
@@ -476,7 +476,8 @@ namespace Rachis
 
 			if (_log.IsInfoEnabled)
 			{
-				_log.Info("Finished applying new topology: {0}", _currentTopology);
+				_log.Info("Finished applying new topology: {0}{1}", _currentTopology,
+					tcc.Previous == null ? ", Previous topology was null - perhaps it is setting topology for the first time?" : String.Empty);
 			}
 
 			OnTopologyChanged(tcc);


### PR DESCRIPTION
WaitForToplogyChange() in a test should wait for topology change that actually changes something and not "dummy" change that sets up topology id
